### PR TITLE
Changes to support e2e encryption

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-quiver",
   "description": "Multi-server Social Provider",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "homepage": "",
   "bugs": {
     "url": "http://github.com/bemasc/freedom-social-quiver/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-quiver",
   "description": "Multi-server Social Provider",
-  "version": "0.1.0",
+  "version": "0.0.3",
   "homepage": "",
   "bugs": {
     "url": "http://github.com/bemasc/freedom-social-quiver/issues"

--- a/src/social2.quiver.json
+++ b/src/social2.quiver.json
@@ -134,7 +134,8 @@
         "clientId": "string",
         "status": "string",
         "lastUpdated": "number",
-        "lastSeen": "number"
+        "lastSeen": "number",
+        "inviteUserData": "string"
       }}
     }
   },

--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -723,7 +723,9 @@ QuiverSocialProvider.prototype.changeRoster = function(userId, clientSuffix, inv
 
   if (clientSuffix) {
     var clientState = this.makeClientState_(userId, clientSuffix);
-    clientState.inviteUserData = inviteUserData;
+    if (inviteUserData) {
+      clientState.inviteUserData = inviteUserData;
+    }
     this.dispatchEvent('onClientState', clientState);
   } else {
     for (var eachClientSuffix in this.clients_[userId]) {

--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -434,6 +434,7 @@ QuiverSocialProvider.prototype.selfDescriptionChanged_ = function() {
 
 /**
  * @param {string} friendUrl
+ * @param {string} inviteUserData
  * @param {Function} cb
  * @private
  */
@@ -716,6 +717,7 @@ QuiverSocialProvider.prototype.logout = function(continuation) {
  * @private
  * @param {string} userId
  * @param {?string=} clientSuffix Optional.
+ * @param {?string} inviteUserData
  **/
 QuiverSocialProvider.prototype.changeRoster = function(userId, clientSuffix, inviteUserData) {
   var userProfile = this.makeProfile_(userId);

--- a/src/socketio.quiver.js
+++ b/src/socketio.quiver.js
@@ -39,7 +39,7 @@ function QuiverSocialProvider(dispatchEvent) {
   this.storage = freedom['core.storage']();
 
   /** @private {string} */
-  this.clientSuffix_ = String(Math.random());
+  this.clientSuffix_ = null;
 
   /** @private {!Object.<string, !Object.<string, QuiverSocialProvider.clientTracker_>>} */
   this.clients_ = {};  // userId, clientSuffix => clientTracker
@@ -190,6 +190,8 @@ QuiverSocialProvider.prototype.login = function(loginOpts, continuation) {
     return;
   }
 
+  this.clientSuffix_ = loginOpts.agent;
+
   this.syncConfiguration_(function() {
     this.clients_[this.configuration_.self.id] = {};
     this.clients_[this.configuration_.self.id][this.clientSuffix_] = QuiverSocialProvider.makeClientTracker_();
@@ -218,7 +220,7 @@ QuiverSocialProvider.prototype.login = function(loginOpts, continuation) {
       connectedCountGoal += friend.servers.length;
       for (var j = 0; j < friend.servers.length; ++j) {
         var friendServer = friend.servers[j];
-        this.connectAsClient(friendServer, friend, onClientConnection);
+        this.connectAsClient(friendServer, friend, null, onClientConnection);
       }
     }
   }.bind(this));
@@ -301,7 +303,7 @@ QuiverSocialProvider.prototype.connectAsOwner = function(serverUrl, continuation
     connection.socket.emit('join', this.configuration_.self.id);
 
     // Connect to self, in order to be able to send messages to my own other clients.
-    this.connectAsClient(serverUrl, this.configuration_.self, continuation);
+    this.connectAsClient(serverUrl, this.configuration_.self, null, continuation);
   }.bind(this)).catch(function(err) {
     continuation(undefined, err);
   });
@@ -317,7 +319,7 @@ QuiverSocialProvider.prototype.disconnect_ = function(serverUrl) {
     }
 };
 
-QuiverSocialProvider.prototype.connectAsClient = function(serverUrl, friend, continuation) {
+QuiverSocialProvider.prototype.connectAsClient = function(serverUrl, friend, inviteUserData, continuation) {
   if (serverUrl[serverUrl.length - 1] != '/') {
     serverUrl = serverUrl + '/';
   }
@@ -340,6 +342,9 @@ QuiverSocialProvider.prototype.connectAsClient = function(serverUrl, friend, con
 
   connection.ready.then(function() {
     var introMsg = this.makeIntroMsg_(friend);
+    if (inviteUserData) {
+      introMsg.inviteUserData = inviteUserData;
+    }
     socket.emit('emit', {
       'rooms': [friend.id],
       'msg': introMsg
@@ -432,7 +437,7 @@ QuiverSocialProvider.prototype.selfDescriptionChanged_ = function() {
  * @param {Function} cb
  * @private
  */
-QuiverSocialProvider.prototype.acceptUserInvitation = function(friendUrl, cb) {
+QuiverSocialProvider.prototype.acceptUserInvitation = function(friendUrl, inviteUserData, cb) {
   var splitIndex = friendUrl.lastIndexOf(':');
   if (splitIndex === -1) {
     // No friend, just a server URL?
@@ -448,7 +453,7 @@ QuiverSocialProvider.prototype.acceptUserInvitation = function(friendUrl, cb) {
   var serverUrl = contact.slice(0, splitPathIndex);
   var userId = contact.slice(splitPathIndex + 1);
 
-  this.addFriend_([serverUrl], userId, [knockCode], null, cb);
+  this.addFriend_([serverUrl], userId, [knockCode], null, inviteUserData, cb);
 };
 
 /**
@@ -456,9 +461,10 @@ QuiverSocialProvider.prototype.acceptUserInvitation = function(friendUrl, cb) {
  * @param {string} userId
  * @param {!Array.<string>} knockCodes
  * @param {?string} nick
+ * @param {?string} inviteUserData
  * @private
  */
-QuiverSocialProvider.prototype.addFriend_ = function(servers, userId, knockCodes, nick, continuation) {
+QuiverSocialProvider.prototype.addFriend_ = function(servers, userId, knockCodes, nick, inviteUserData, continuation) {
   console.log('Adding Friend!', arguments);
   var friendDesc = this.configuration_.friends[userId];
   if (!friendDesc) {
@@ -490,7 +496,7 @@ QuiverSocialProvider.prototype.addFriend_ = function(servers, userId, knockCodes
     friendDesc.nick = nick;
   }
   this.syncConfiguration_(function() {
-    this.connectAsClient(servers[0], friendDesc, continuation);
+    this.connectAsClient(servers[0], friendDesc, inviteUserData, continuation);
   }.bind(this));
 };
 
@@ -711,12 +717,13 @@ QuiverSocialProvider.prototype.logout = function(continuation) {
  * @param {string} userId
  * @param {?string=} clientSuffix Optional.
  **/
-QuiverSocialProvider.prototype.changeRoster = function(userId, clientSuffix) {
+QuiverSocialProvider.prototype.changeRoster = function(userId, clientSuffix, inviteUserData) {
   var userProfile = this.makeProfile_(userId);
   this.dispatchEvent('onUserProfile', userProfile);
 
   if (clientSuffix) {
     var clientState = this.makeClientState_(userId, clientSuffix);
+    clientState.inviteUserData = inviteUserData;
     this.dispatchEvent('onClientState', clientState);
   } else {
     for (var eachClientSuffix in this.clients_[userId]) {
@@ -769,7 +776,7 @@ QuiverSocialProvider.prototype.onMessage = function(serverUrl, msg) {
       if (!this.clients_[fromUserId][msg.fromClient]) {
         this.clients_[fromUserId][msg.fromClient] = QuiverSocialProvider.makeClientTracker_();
       }
-      this.addFriend_(msg.servers, fromUserId, msg.knockCodes, msg.nick, function() {
+      this.addFriend_(msg.servers, fromUserId, msg.knockCodes, msg.nick, null, function() {
         var gotIntro = this.clients_[fromUserId][msg.fromClient].gotIntro;
         if (!gotIntro[serverUrl]) {
           gotIntro[serverUrl] = true;
@@ -785,7 +792,7 @@ QuiverSocialProvider.prototype.onMessage = function(serverUrl, msg) {
             'msg': introMsg
           });
         }
-        this.changeRoster(fromUserId, msg.fromClient);
+        this.changeRoster(fromUserId, msg.fromClient, msg.inviteUserData);
       }.bind(this));
     }
   } else if (msg.cmd === 'disconnected') {

--- a/src/socketio.quiver.json
+++ b/src/socketio.quiver.json
@@ -61,7 +61,7 @@
 
       "acceptUserInvitation": {
        "type": "method",
-        "value": ["string"]
+        "value": ["string", "string"]
       },
 
       "sendEmail": {
@@ -134,7 +134,8 @@
         "clientId": "string",
         "status": "string",
         "lastUpdated": "number",
-        "lastSeen": "number"
+        "lastSeen": "number",
+        "inviteUserData": "string"
       }}
     }
   },


### PR DESCRIPTION
Changes to support e2d encryption in freedom-social-quiver.  All encryption + decryption will be done in uProxy.
- Set clientSuffix_ in login, using loginOpts.agent (same logic as Firebase social providers).  clientId is now in the form of `userId + ':' + publicKey` (unfortunately we can't easily set clientId=publicKey because `sendMessage` takes the clientId as input, and relies on it to contain the userId
- `acceptUserInvitation` now takes an additional `inviteUserData` string param.  If Alice sends Bob a Quiver invite, Bob's uProxy should pass some encrypted data (Bob's public key) as the inviteUserData.  Then on Alice's side, when she gets an onClientState for Bob, it will contain this string.

After corresponding changes are made to uProxy, we can remove the knockCodes from Quiver (uProxy will add it's own permission code to invites, which will be useful for other networks, and for initializing get/share permission as part of invites)
